### PR TITLE
hotfix: monitor_level

### DIFF
--- a/lib/libreels.lua
+++ b/lib/libreels.lua
@@ -371,7 +371,7 @@ reels.init = function()
   audio.level_cut(1)
   audio.level_adc_cut(1)
   audio.level_eng_cut(0)
-  params:set("monitor", rec_vol)
+  params:set("monitor_level", rec_vol)
   params:add_option ( "tape_switch", "Reels:", { "background", "active" }, 1 )
   params:set_action( "tape_switch", function(x) if x == 1 then reels.active = false else reels.active = true end end )
   params:add_separator()
@@ -801,7 +801,7 @@ function reels:enc(n, d)
     elseif n == 2 then
       if not settings then
         rec_vol = util.clamp(rec_vol + d / 100, 0, 1)
-        params:set("monitor", rec_vol)
+        params:set("monitor_level", rec_vol)
         audio.level_adc_cut(rec_vol)
         softcut.rec_level(sel, rec_vol)
       elseif settings then


### PR DESCRIPTION
assigns `monitor_level` to previous `monitor` fix (paramset `monitor` is invalid index)